### PR TITLE
Fixed wrong transmission counter

### DIFF
--- a/source/main/gui/OverlayWrapper.cpp
+++ b/source/main/gui/OverlayWrapper.cpp
@@ -795,7 +795,7 @@ void OverlayWrapper::UpdateLandVehicleHUD(RoR::GfxActor* ga)
     int vehicle_getgear = ga->GetSimDataBuffer().simbuf_gear;
     if (vehicle_getgear > 0)
     {
-        size_t numgears = ga->GetSimDataBuffer().simbuf_gear;
+        size_t numgears = ga->GetAttributes().xa_num_gears;
         String gearstr = TOSTRING(vehicle_getgear) + "/" + TOSTRING(numgears);
         guiGear->setCaption(gearstr);
         guiGear3D->setCaption(gearstr);


### PR DESCRIPTION
Fixes:
> Load gavril or agora bus and switch to dash view. Transmission counter is wrong. It shows 1/1 2/2... instead of 1/6 2/6... Master is fine.
