### PR TITLE
Fixed broken vehicle lights

### DIFF
--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -497,6 +497,8 @@ void ActorSpawner::FinalizeRig()
     m_actor->ar_lowest_contacting_node = FindLowestContactingNodeInRig();
 
     this->UpdateCollcabContacterNodes();
+
+    m_flex_factory.SaveFlexbodiesToCache();
 }
 
 /* -------------------------------------------------------------------------- */
@@ -2598,6 +2600,7 @@ void ActorSpawner::ProcessTie(RigDef::Tie & def)
     tie.ti_tying = false;
     tie.ti_tied = false;
     tie.ti_beam = & beam;
+    tie.ti_locked_ropable = nullptr;
     tie.ti_command_value = -1.f;
     tie.ti_contract_speed = def.auto_shorten_rate;
     tie.ti_max_stress = def.max_stress;
@@ -6773,16 +6776,19 @@ void ActorSpawner::SetupNewEntity(Ogre::Entity* ent, Ogre::ColourValue simple_co
     }
 }
 
-void ActorSpawner::FinalizeGfxSetup()
+void ActorSpawner::CreateGfxActor()
 {
-    // Check and warn if there are unclaimed managed materials
-    // TODO &*&*
-
     // Create the actor
     m_actor->m_gfx_actor = std::unique_ptr<RoR::GfxActor>(
         new RoR::GfxActor(m_actor, m_custom_resource_group, m_gfx_nodes, m_props, m_driverseat_prop_index));
 
     m_actor->GetGfxActor()->UpdateSimDataBuffer(); // Initial fill (to setup flexbodies + flexbodywheels)
+}
+
+void ActorSpawner::FinalizeGfxSetup()
+{
+    // Check and warn if there are unclaimed managed materials
+    // TODO &*&*
 
     // Process special materials
     for (auto& entry: m_material_substitutions)

--- a/source/main/physics/RigSpawner.h
+++ b/source/main/physics/RigSpawner.h
@@ -927,6 +927,8 @@ private:
     */
     void SetupNewEntity(Ogre::Entity* e, Ogre::ColourValue simple_color);
 
+    void CreateGfxActor();
+
     /**
     * Factory of GfxActor; invoke after all gfx setup was done.
     */

--- a/source/main/physics/RigSpawner_ProcessControl.cpp
+++ b/source/main/physics/RigSpawner_ProcessControl.cpp
@@ -357,6 +357,11 @@ Actor *ActorSpawner::SpawnActor()
     // Section 'screwprops'
     PROCESS_SECTION_IN_ALL_MODULES(RigDef::File::KEYWORD_SCREWPROPS, screwprops, ProcessScrewprop);
 
+    this->CreateGfxActor(); // Required in the 'flexbodies' section
+
+    // Section 'flexbodies' (Uses generated nodes; needs GfxActor to exist)
+    PROCESS_SECTION_IN_ALL_MODULES(RigDef::File::KEYWORD_FLEXBODIES, flexbodies, ProcessFlexbody);
+
     // Section 'fixes'
     PROCESS_SECTION_IN_ALL_MODULES(RigDef::File::KEYWORD_FIXES, fixes, ProcessFixedNode);
 
@@ -371,11 +376,7 @@ Actor *ActorSpawner::SpawnActor()
 #endif // USE_OPENAL
 
     this->FinalizeRig();
-    this->FinalizeGfxSetup(); // Creates the GfxActor
-
-    // Section 'flexbodies' (Uses generated nodes; needs GfxActor to exist)
-    PROCESS_SECTION_IN_ALL_MODULES(RigDef::File::KEYWORD_FLEXBODIES, flexbodies, ProcessFlexbody);
-    m_flex_factory.SaveFlexbodiesToCache();
+    this->FinalizeGfxSetup();
 
     // Pass ownership
     Actor *rig = m_actor;


### PR DESCRIPTION
Fixes:
> Lights don't work on some vehicles when pressing N. Master works.
1980Yota.zip

Apparently `FinalizeGfxSetup()` must be the last step. But that means the GfxActor needs to be created somewhat earlier - so seperately.