### PR TITLE
 Fixed top menubar actor list

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -2311,14 +2311,14 @@ void SimController::RemoveActor(Actor* actor)
     m_actor_manager.RemoveActorInternal(actor->ar_instance_id);
 }
 
-int SimController::GetNumActors() const
+std::vector<Actor*> SimController::GetActors() const
 {
-    return m_actor_manager.CountActorsInternal();
+    return m_actor_manager.GetActors();
 }
 
-int SimController::GetNumPlayableActors() const
+std::vector<Actor*> SimController::GetPlayableActors() const
 {
-    return m_actor_manager.CountPlayableActorsInternal();
+    return m_actor_manager.GetPlayableActors();
 }
 
 bool SimController::AreControlsLocked() const

--- a/source/main/gameplay/RoRFrameListener.h
+++ b/source/main/gameplay/RoRFrameListener.h
@@ -72,8 +72,9 @@ public:
     void   RemovePlayerActor     ();
     void   RemoveActor           (Actor* actor);
     void   RemoveActorByCollisionBox(std::string const & ev_src_instance_name, std::string const & box_name); ///< Scripting utility. TODO: Does anybody use it? ~ only_a_ptr, 08/2017
-    int    GetNumActors          () const; //!< All actors
-    int    GetNumPlayableActors  () const;
+
+    std::vector<Actor*>          GetActors          () const; //!< All actors
+    std::vector<Actor*>          GetPlayableActors  () const;
 
     // Scripting interface
     double getTime               () { return m_time; }

--- a/source/main/gui/panels/GUI_TopMenubar.cpp
+++ b/source/main/gui/panels/GUI_TopMenubar.cpp
@@ -40,7 +40,7 @@ void RoR::GUI::TopMenubar::Update()
 
     const char* sim_title = "Simulation"; // TODO: Localize all!
     Str<50> actors_title;
-    actors_title << "Actors (" << App::GetSimController()->GetNumPlayableActors() << ")";
+    actors_title << "Actors (" << App::GetSimController()->GetPlayableActors().size() << ")";
     const char* tools_title = "Tools";
 
     float panel_target_width = 
@@ -365,12 +365,11 @@ bool RoR::GUI::TopMenubar::ShouldDisplay(ImVec2 window_pos)
 void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
 {
     // Count actors owned by the player
-    size_t num_actors_total = App::GetSimController()->GetNumActors();
+    size_t num_actors_total = App::GetSimController()->GetActors().size();
     size_t num_actors_player = 0;
-    for (size_t i = 0; i < num_actors_total; ++i)
+    for (Actor* actor : App::GetSimController()->GetActors())
     {
-        Actor* actor = App::GetSimController()->GetActorById(static_cast<int>(i));
-        if ((actor != nullptr) && (actor->ar_net_source_id == user.uniqueid))
+        if (actor->ar_net_source_id == user.uniqueid)
         {
             ++num_actors_player;
         }
@@ -396,10 +395,9 @@ void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
     ImGui::PopStyleColor();
 
     // Display actor list
-    for (size_t i = 0; i < num_actors_total; ++i)
+    for (auto actor : App::GetSimController()->GetActors())
     {
-        Actor* actor = App::GetSimController()->GetActorById(static_cast<int>(i));
-        if ((actor != nullptr) && (!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
+        if ((!actor->ar_hide_in_actor_list) && (actor->ar_net_source_id == user.uniqueid))
         {
             char actortext_buf[400];
             snprintf(actortext_buf, 400, "  + %s (%s)", actor->ar_design_name.c_str(), actor->ar_filename.c_str());
@@ -413,23 +411,22 @@ void RoR::GUI::TopMenubar::DrawMpUserToActorList(RoRnet::UserInfo &user)
 
 void RoR::GUI::TopMenubar::DrawActorListSinglePlayer()
 {
-    if (App::GetSimController()->GetNumPlayableActors() == 0)
+    auto actor_list = App::GetSimController()->GetPlayableActors();
+
+    if (actor_list.empty())
     {
         ImGui::PushStyleColor(ImGuiCol_Text, GRAY_HINT_TEXT);
         ImGui::Text("None spawned yet");
         ImGui::Text("Use [Simulation] menu");
         ImGui::PopStyleColor();
-        return;
     }
-
-    size_t num_actors = App::GetSimController()->GetNumActors();
-    for (size_t i = 0; i < num_actors; ++i)
+    else
     {
-        Actor* actor = App::GetSimController()->GetActorById(i);
-        if ((actor != nullptr) && (!actor->ar_hide_in_actor_list))
+        int i = 0;
+        for (auto actor : actor_list)
         {
             char text_buf[200];
-            snprintf(text_buf, 200, "[%d] %s", i, actor->ar_design_name.c_str());
+            snprintf(text_buf, 200, "[%d] %s", i++, actor->ar_design_name.c_str());
             if (ImGui::Button(text_buf)) // Button clicked?
             {
                 App::GetSimController()->SetPlayerActor(actor);

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1671,28 +1671,28 @@ std::shared_ptr<RigDef::File> ActorManager::FetchActorDef(const char* filename, 
     }
 }
 
-int ActorManager::CountActorsInternal() const
+std::vector<Actor*> ActorManager::GetActors() const
 {
-    int count = 0;
+    std::vector<Actor*> actors;
     for (int t = 0; t < m_free_actor_slot; t++)
     {
         if (m_actors[t] != nullptr)
         {
-            ++count;
+            actors.emplace_back(m_actors[t]);
         }
     }
-    return count;
+    return actors;
 }
 
-int ActorManager::CountPlayableActorsInternal() const // for selector GUI
+std::vector<Actor*> ActorManager::GetPlayableActors() const
 {
-    int count = 0;
+    std::vector<Actor*> actors;
     for (int t = 0; t < m_free_actor_slot; t++)
     {
         if ((m_actors[t] != nullptr) && (!m_actors[t]->ar_hide_in_actor_list))
         {
-            ++count;
+            actors.emplace_back(m_actors[t]);
         }
     }
-    return count;
+    return actors;
 }

--- a/source/main/physics/BeamFactory.h
+++ b/source/main/physics/BeamFactory.h
@@ -88,8 +88,6 @@ public:
     Actor*         GetActorByIdInternal(int number); //!< DO NOT CALL DIRECTLY! Use `SimController` for public interface
     Actor*         FindActorInsideBox(Collisions* collisions, const Ogre::String& inst, const Ogre::String& box);
     void           UpdateAirbrakeInput(float dt);
-    int            CountActorsInternal() const;
-    int            CountPlayableActorsInternal() const; //!< For selector GUI
 
     // Visual updates
     void           UpdateActorVisuals(float dt, Actor* player_actor); // LEGACY; reads data directly from Actor, requires physics to be halted
@@ -102,6 +100,9 @@ public:
     void           AddRef() {};  // we have to add this to be able to use the class as reference inside scripts
     void           Release() {};
 #endif
+
+    std::vector<Actor*> GetActors() const;
+    std::vector<Actor*> GetPlayableActors() const;
 
     // A list of all beams interconnecting two actors
     std::map<beam_t*, std::pair<Actor*, Actor*>> inter_actor_links;


### PR DESCRIPTION
Fixes:
> Load simple terrain and spawn agora. Go to top bar see Actors, it shows agora fine.
Remove agora and respawn it. Go to top bar see Actors: empty.

The internal actor list (`m_actors`) is a sparse vector, which is why you cannot access the Nth truck by simply reading the Nth element of the vector.