### PR TITLE
Fixed another segfault

### DIFF
--- a/source/main/physics/BeamSlideNode.cpp
+++ b/source/main/physics/BeamSlideNode.cpp
@@ -64,9 +64,13 @@ void Actor::ToggleSlideNodeLock()
                 (player_actor_id == i && itNode->sn_attach_self)))
                 continue;
 
-            current = GetClosestRailOnActor(RoR::App::GetSimController()->GetActorById(i), (*itNode));
-            if (current.second < closest.second)
-                closest = current;
+            Actor* actor = RoR::App::GetSimController()->GetActorById(i);
+            if (actor)
+            {
+                current = GetClosestRailOnActor(actor, (*itNode));
+                if (current.second < closest.second)
+                    closest = current;
+            }
         } // this many
 
         itNode->AttachToRail(closest.first);
@@ -78,6 +82,7 @@ void Actor::ToggleSlideNodeLock()
 std::pair<RailGroup*, Ogre::Real> Actor::GetClosestRailOnActor(Actor* actor, const SlideNode& node)
 {
     std::pair<RailGroup*, Ogre::Real> closest((RailGroup*)NULL, std::numeric_limits<Ogre::Real>::infinity());
+
     RailSegment* curRail = NULL;
     Ogre::Real lenToCurRail = std::numeric_limits<Ogre::Real>::infinity();
 


### PR DESCRIPTION
Once again truck array related. (See the #dev chat on Discord).
```
Thread 1 "RoR" received signal SIGSEGV, Segmentation fault.
Actor::GetClosestRailOnActor (this=this@entry=0x55555d5e9b00, actor=0x0, node=...) at /home/archie/rigs-of-rods/source/main/physics/BeamSlideNode.cpp:84
84        for (std::vector<RailGroup*>::iterator itGroup = actor->m_railgroups.begin();
(gdb) bt
#0  Actor::GetClosestRailOnActor (this=this@entry=0x55555d5e9b00, actor=0x0, node=...) at /home/archie/rigs-of-rods/source/main/physics/BeamSlideNode.cpp:84
```