### PR TITLE
Fixed diagonal walking animation

### DIFF
--- a/source/main/gameplay/Character.cpp
+++ b/source/main/gameplay/Character.cpp
@@ -340,7 +340,7 @@ void Character::update(float dt)
                 accel = 3.0f * tmpRun;
             // animation missing for that
             position += dt * m_character_h_speed * 0.5f * accel * Vector3(cos(m_character_rotation.valueRadians() - Math::HALF_PI), 0.0f, sin(m_character_rotation.valueRadians() - Math::HALF_PI));
-            if (!isswimming)
+            if (!isswimming && not_walking)
             {
                 this->SetAnimState("Side_step", -dt);
                 idleanim = false;
@@ -354,7 +354,7 @@ void Character::update(float dt)
                 accel = 3.0f * tmpRun;
             // animation missing for that
             position += dt * m_character_h_speed * 0.5f * accel * Vector3(cos(m_character_rotation.valueRadians() + Math::HALF_PI), 0.0f, sin(m_character_rotation.valueRadians() + Math::HALF_PI));
-            if (!isswimming)
+            if (!isswimming && not_walking)
             {
                 this->SetAnimState("Side_step", dt);
                 idleanim = false;


### PR DESCRIPTION
Fixes:
> Walk or run the rorbot and press 'a' or 'd': no animation (since 415c8d3)