### PR TITLE
Fixed visual glitch when trucks are spawned sleeping

### DIFF
--- a/source/main/gfx/DustManager.cpp
+++ b/source/main/gfx/DustManager.cpp
@@ -292,10 +292,11 @@ void RoR::GfxScene::BufferSimulationData()
     m_live_gfx_actors.clear();
     for (GfxActor* a: m_all_gfx_actors)
     {
-        if (a->IsActorLive())
+        if (a->IsActorLive() || !a->IsActorInitialized())
         {
             a->UpdateSimDataBuffer();
             m_live_gfx_actors.push_back(a);
+            a->InitializeActor();
         }
     }
 

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -75,7 +75,8 @@ RoR::GfxActor::GfxActor(Actor* actor, std::string ogre_resource_group,
     m_driverseat_prop_index(driverseat_prop_idx),
     m_prop_anim_crankfactor_prev(0.f),
     m_prop_anim_shift_timer(0.f),
-    m_beaconlight_active(false)
+    m_beaconlight_active(false),
+    m_initialized(false)
 {
     // Setup particles
     RoR::GfxScene& dustman = RoR::App::GetSimController()->GetGfxScene();

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -260,6 +260,8 @@ public:
     void                      SetRodsVisible     (bool visible);
     void                      ScaleActor         (Ogre::Vector3 relpos, float ratio);
     bool                      IsActorLive        () const; //!< Should the visuals be updated for this actor?
+    bool                      IsActorInitialized () const  { return m_initialized; } //!< Temporary TODO: Remove once the spawn routine is fixed
+    void                      InitializeActor    ()        { m_initialized = true; } //!< Temporary TODO: Remove once the spawn routine is fixed
     void                      UpdateSimDataBuffer(); //!< Copies sim. data from `Actor` to `GfxActor` for later update
     void                      SetWheelVisuals    (uint16_t index, WheelGfx wheel_gfx);
     void                      CalculateDriverPos (Ogre::Vector3& out_pos, Ogre::Quaternion& out_rot);
@@ -334,6 +336,8 @@ private:
     float                       m_prop_anim_crankfactor_prev;
     float                       m_prop_anim_shift_timer;
     int                         m_prop_anim_prev_gear;
+
+    bool                        m_initialized;
 
     SimBuffer                   m_simbuf;
 


### PR DESCRIPTION
Temporary workaround until the spawn routine is fixed properly.

Fixes:
> The interstate 8st trailer spawns at (0,0,0) (since 7767982)
> The 20ft container has spawn issues (wrong position / orientation) (since 5aa586c)