### PR TITLE
Fixed UpdateRods()

### DIFF
--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -878,7 +878,7 @@ void RoR::GfxActor::CycleDebugViews()
     }
 }
 
-void RoR::GfxActor::AddRod(int beam_index,  int node1_index, int node2_index, const char* material_name, bool visible, float diameter_meters)
+void RoR::GfxActor::AddRod(int beam_index, const char* material_name, bool visible, float diameter_meters)
 {
     try
     {
@@ -901,8 +901,6 @@ void RoR::GfxActor::AddRod(int beam_index,  int node1_index, int node2_index, co
         rod.rod_diameter_mm = uint16_t(diameter_meters * 1000.f);
 
         rod.rod_beam_index = static_cast<uint16_t>(beam_index);
-        rod.rod_node1 = static_cast<uint16_t>(node1_index);
-        rod.rod_node2 = static_cast<uint16_t>(node2_index);
 
         m_rods.push_back(rod);
     }
@@ -919,16 +917,26 @@ void RoR::GfxActor::UpdateRods()
 
     for (Rod& rod: m_rods)
     {
-        Ogre::Vector3 pos1 = m_actor->ar_nodes[rod.rod_node1].AbsPosition;
-        Ogre::Vector3 pos2 = m_actor->ar_nodes[rod.rod_node2].AbsPosition;
+        int i = rod.rod_beam_index;
+        if (m_actor->ar_beams[i].bm_disabled || m_actor->ar_beams[i].bm_broken)
+        {
+            rod.rod_scenenode->setVisible(false, /*cascade=*/ false);
+        }
+        else if (m_actor->ar_beams[i].bm_type != BEAM_VIRTUAL)
+        {
+            rod.rod_scenenode->setVisible(true, /*cascade=*/ false);
 
-        // Classic method
-        float beam_diameter = static_cast<float>(rod.rod_diameter_mm) * 0.001;
-        float beam_length = pos1.distance(pos2);
+            Ogre::Vector3 pos1 = m_actor->ar_beams[i].p1->AbsPosition;
+            Ogre::Vector3 pos2 = m_actor->ar_beams[i].p2->AbsPosition;
 
-        rod.rod_scenenode->setPosition(pos1.midPoint(pos2));
-        rod.rod_scenenode->setScale(beam_diameter, beam_length, beam_diameter);
-        rod.rod_scenenode->setOrientation(GfxActor::SpecialGetRotationTo(Ogre::Vector3::UNIT_Y, (pos1 - pos2)));
+            // Classic method
+            float beam_diameter = static_cast<float>(rod.rod_diameter_mm) * 0.001;
+            float beam_length = pos1.distance(pos2);
+
+            rod.rod_scenenode->setPosition(pos1.midPoint(pos2));
+            rod.rod_scenenode->setScale(beam_diameter, beam_length, beam_diameter);
+            rod.rod_scenenode->setOrientation(GfxActor::SpecialGetRotationTo(Ogre::Vector3::UNIT_Y, (pos1 - pos2)));
+        }
     }
 }
 

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -136,8 +136,6 @@ public:
         Ogre::SceneNode* rod_scenenode;
         uint16_t         rod_beam_index;  //!< Index of the associated `beam_t` instance; assumes Actor has at most 65536 beams (RoR doesn't have a soft limit now, but until v0.4.8 it was 5000 beams).
         uint16_t         rod_diameter_mm; //!< Diameter in millimeters
-        uint16_t         rod_node1;       //!< Node index - assumes the Actor has at most 65536 nodes (RoR doesn't have a soft limit now, but until v0.4.8 it was 1000 nodes).
-        uint16_t         rod_node2;       //!< Node index - assumes the Actor has at most 65536 nodes (RoR doesn't have a soft limit now, but until v0.4.8 it was 1000 nodes).
     };
 
     struct WheelGfx
@@ -255,7 +253,7 @@ public:
     void                      SetVideoCamState   (VideoCamState state);
     void                      UpdateVideoCameras (float dt_sec);
     void                      UpdateParticles    (float dt_sec);
-    void                      AddRod             (int beam_index, int node1_index, int node2_index, const char* material_name, bool visible, float diameter_meters);
+    void                      AddRod             (int beam_index, const char* material_name, bool visible, float diameter_meters);
     void                      UpdateRods         ();
     void                      SetRodsVisible     (bool visible);
     void                      ScaleActor         (Ogre::Vector3 relpos, float ratio);

--- a/source/main/physics/RigSpawner.cpp
+++ b/source/main/physics/RigSpawner.cpp
@@ -6896,9 +6896,7 @@ void ActorSpawner::FinalizeGfxSetup()
     // Process rods (beam visuals)
     for (BeamVisualsTicket& bv: m_beam_visuals_queue)
     {
-        int node1 = m_actor->ar_beams[bv.beam_index].p1->pos;
-        int node2 = m_actor->ar_beams[bv.beam_index].p2->pos;
-        m_actor->m_gfx_actor->AddRod(bv.beam_index, node1, node2, bv.material_name.c_str(), bv.visible, bv.diameter);
+        m_actor->m_gfx_actor->AddRod(bv.beam_index, bv.material_name.c_str(), bv.visible, bv.diameter);
     }
 
     //add the cab visual


### PR DESCRIPTION
- Added the missing rod visibility update routine
- Removed the static indices (rod_node1, rod_node1) from the Rod struct, since the beam endpoints can change during the simulation (for example in `ToggleTies()`)

Fixes:
> Ties are invisble (since 27835c8)