### PR TITLE
Fixed UpdateRods() - second try

### DIFF
--- a/source/main/datatypes/beam_t.h
+++ b/source/main/datatypes/beam_t.h
@@ -45,6 +45,7 @@ struct beam_t
     short bounded;      //!< { SHOCK1=1, SHOCK2=2, SUPPORTBEAM=3, ROPE=4 }
     short bm_type;      //!< { BEAM_NORMAL, BEAM_HYDRO, BEAM_VIRTUAL }
     bool bm_inter_actor;       //!< in case p2 is on another actor
+    Actor* bm_locked_actor;    //!< in case p2 is on another actor
 
     /// Multipurpose; excludes beam from physics, controls visibility (gfx) and indicates multiple other states (hooks/ties).
     /// Users:

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -915,11 +915,12 @@ void RoR::GfxActor::AddRod(int beam_index,  int node1_index, int node2_index, co
 
 void RoR::GfxActor::UpdateRods()
 {
-    // TODO: Apply visibility updates from a queue (to be implemented!)
-    // fulltext-label: QUEUE_VIS_CHANGE
-
     for (Rod& rod: m_rods)
     {
+        rod.rod_scenenode->setVisible(rod.rod_is_visible);
+        if (!rod.rod_is_visible)
+            continue;
+
         Ogre::Vector3 pos1 = m_actor->ar_nodes[rod.rod_node1].AbsPosition;
         Ogre::Vector3 pos2 = m_actor->ar_nodes[rod.rod_node2].AbsPosition;
 
@@ -1070,6 +1071,15 @@ void RoR::GfxActor::UpdateSimDataBuffer()
     for (int i = 0; i < num_nodes; ++i)
     {
         m_simbuf.simbuf_nodes.get()[i].AbsPosition = m_actor->ar_nodes[i].AbsPosition;
+    }
+
+    // beams
+    for (Rod& rod: m_rods)
+    {
+        const beam_t& beam = m_actor->ar_beams[rod.rod_beam_index];
+        rod.rod_node1 = static_cast<uint16_t>(beam.p1->pos);
+        rod.rod_node2 = static_cast<uint16_t>(beam.p2->pos);
+        rod.rod_is_visible = (beam.bm_disabled || beam.bm_broken);
     }
 
     // airbrakes

--- a/source/main/gfx/GfxActor.cpp
+++ b/source/main/gfx/GfxActor.cpp
@@ -904,6 +904,8 @@ void RoR::GfxActor::AddRod(int beam_index,  int node1_index, int node2_index, co
         rod.rod_beam_index = static_cast<uint16_t>(beam_index);
         rod.rod_node1 = static_cast<uint16_t>(node1_index);
         rod.rod_node2 = static_cast<uint16_t>(node2_index);
+        rod.rod_target_actor = m_actor;
+        rod.rod_is_visible = false;
 
         m_rods.push_back(rod);
     }
@@ -921,8 +923,10 @@ void RoR::GfxActor::UpdateRods()
         if (!rod.rod_is_visible)
             continue;
 
-        Ogre::Vector3 pos1 = m_actor->ar_nodes[rod.rod_node1].AbsPosition;
-        Ogre::Vector3 pos2 = m_actor->ar_nodes[rod.rod_node2].AbsPosition;
+        NodeData* nodes1 = this->GetSimNodeBuffer();
+        Ogre::Vector3 pos1 = nodes1[rod.rod_node1].AbsPosition;
+        NodeData* nodes2 = rod.rod_target_actor->GetGfxActor()->GetSimNodeBuffer();
+        Ogre::Vector3 pos2 = nodes2[rod.rod_node2].AbsPosition;
 
         // Classic method
         float beam_diameter = static_cast<float>(rod.rod_diameter_mm) * 0.001;
@@ -1079,7 +1083,11 @@ void RoR::GfxActor::UpdateSimDataBuffer()
         const beam_t& beam = m_actor->ar_beams[rod.rod_beam_index];
         rod.rod_node1 = static_cast<uint16_t>(beam.p1->pos);
         rod.rod_node2 = static_cast<uint16_t>(beam.p2->pos);
-        rod.rod_is_visible = (beam.bm_disabled || beam.bm_broken);
+        if (beam.bm_inter_actor)
+        {
+            rod.rod_target_actor = beam.bm_locked_actor;
+        }
+        rod.rod_is_visible = !beam.bm_disabled && !beam.bm_broken;
     }
 
     // airbrakes

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -129,15 +129,18 @@ public:
         Ogre::Vector3 AbsPosition;
     };
 
-    /// Visuals of softbody beam (`beam_t` struct)
+    /// Visuals of softbody beam (`beam_t` struct); Partially updated along with SimBuffer
     struct Rod
     {
         // We don't keep pointer to the Ogre::Entity - we rely on the SceneNode keeping it attached all the time.
         Ogre::SceneNode* rod_scenenode;
         uint16_t         rod_beam_index;  //!< Index of the associated `beam_t` instance; assumes Actor has at most 65536 beams (RoR doesn't have a soft limit now, but until v0.4.8 it was 5000 beams).
         uint16_t         rod_diameter_mm; //!< Diameter in millimeters
-        uint16_t         rod_node1;       //!< Node index - assumes the Actor has at most 65536 nodes (RoR doesn't have a soft limit now, but until v0.4.8 it was 1000 nodes).
-        uint16_t         rod_node2;       //!< Node index - assumes the Actor has at most 65536 nodes (RoR doesn't have a soft limit now, but until v0.4.8 it was 1000 nodes).
+
+        // Assumption: Actor has at most 65536 nodes (RoR doesn't have a soft limit right now, but until v0.4.8 it was 1000 nodes).
+        uint16_t         rod_node1;         //!< Node index - may change during simulation!
+        uint16_t         rod_node2;         //!< Node index - may change during simulation!
+        bool             rod_is_visible:1;
     };
 
     struct WheelGfx

--- a/source/main/gfx/GfxActor.h
+++ b/source/main/gfx/GfxActor.h
@@ -140,7 +140,8 @@ public:
         // Assumption: Actor has at most 65536 nodes (RoR doesn't have a soft limit right now, but until v0.4.8 it was 1000 nodes).
         uint16_t         rod_node1;         //!< Node index - may change during simulation!
         uint16_t         rod_node2;         //!< Node index - may change during simulation!
-        bool             rod_is_visible:1;
+        Actor*           rod_target_actor;
+        bool             rod_is_visible;
     };
 
     struct WheelGfx

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -2998,6 +2998,8 @@ void Actor::setDetailLevel(int v)
 
 void Actor::AddInterActorBeam(beam_t* beam, Actor* a, Actor* b)
 {
+    beam->bm_locked_actor = b;
+
     auto pos = std::find(ar_inter_beams.begin(), ar_inter_beams.end(), beam);
     if (pos == ar_inter_beams.end())
     {
@@ -3049,6 +3051,7 @@ void Actor::DisjoinInterActorBeams()
         auto actor_pair = it->second;
         if (this == actor_pair.first || this == actor_pair.second)
         {
+            it->first->bm_locked_actor = nullptr;
             it->first->bm_inter_actor = false;
             it->first->bm_disabled = true;
             inter_actor_links->erase(it++);

--- a/source/main/physics/BeamForcesEuler.cpp
+++ b/source/main/physics/BeamForcesEuler.cpp
@@ -1844,7 +1844,6 @@ void Actor::calcHooks()
                             else
                             {
                                 //force exceeded reset the hook node
-                                // TODO: request hiding of the visuals -- search: QUEUE_VIS_CHANGE
                                 it->hk_locked = UNLOCKED;
                                 it->hk_lock_node = 0;
                                 it->hk_locked_actor = 0;


### PR DESCRIPTION
- Added the missing rod visibility update routine
- Removed the static indices (rod_node1, rod_node1) from the Rod struct, since the beam endpoints can change during the simulation (for example in `ToggleTies()`)
- Handled interconnect beams

Fixes:
> Ties are invisble (since 27835c8)