### PR TITLE
Fixed the interactive truck reset stuttering

### DIFF
--- a/source/main/gameplay/RoRFrameListener.cpp
+++ b/source/main/gameplay/RoRFrameListener.cpp
@@ -820,7 +820,8 @@ void SimController::UpdateInputEvents(float dt)
                         scale *= RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LSHIFT) ? 3.0f : 1.0f;
                         scale *= RoR::App::GetInputEngine()->isKeyDown(OIS::KC_LCONTROL) ? 10.0f : 1.0f;
 
-                        m_player_actor->displace(translation * scale, rotation * scale);
+                        m_player_actor->RequestRotation(rotation * scale);
+                        m_player_actor->RequestTranslation(translation * scale);
 
                         m_advanced_vehicle_repair_timer = 0.0f;
                     }

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -1314,36 +1314,14 @@ void Actor::RequestActorReset(bool keepPosition)
         m_reset_request = REQUEST_RESET_ON_INIT_POS;
 }
 
-void Actor::displace(Vector3 translation, float rotation)
+void Actor::RequestRotation(float rotation)
 {
-    if (rotation != 0.0f)
-    {
-        Vector3 rotation_center = GetRotationCenter();
-        Quaternion rot = Quaternion(Radian(rotation), Vector3::UNIT_Y);
+    m_rotation_request += rotation;
+}
 
-        for (int i = 0; i < ar_num_nodes; i++)
-        {
-            ar_nodes[i].AbsPosition -= rotation_center;
-            ar_nodes[i].AbsPosition = rot * ar_nodes[i].AbsPosition;
-            ar_nodes[i].AbsPosition += rotation_center;
-            ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
-        }
-    }
-
-    if (translation != Vector3::ZERO)
-    {
-        for (int i = 0; i < ar_num_nodes; i++)
-        {
-            ar_nodes[i].AbsPosition += translation;
-            ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
-        }
-    }
-
-    if (rotation != 0.0f || translation != Vector3::ZERO)
-    {
-        updateBoundingBox();
-        calculateAveragePosition();
-    }
+void Actor::RequestTranslation(Vector3 translation)
+{
+    m_translation_request += translation;
 }
 
 Ogre::Vector3 Actor::GetRotationCenter()
@@ -1548,7 +1526,7 @@ void Actor::ForceFeedbackStep(int steps)
     }
 }
 
-void Actor::UpdateAngelScriptEvents(float dt)
+void Actor::HandleAngelScriptEvents(float dt)
 {
 #ifdef USE_ANGELSCRIPT
 
@@ -1561,10 +1539,43 @@ void Actor::UpdateAngelScriptEvents(float dt)
 #endif // USE_ANGELSCRIPT
 }
 
-void Actor::HandleResetRequests(float dt)
+void Actor::HandleInputEvents(float dt)
 {
+    if (m_rotation_request != 0.0f)
+    {
+        Vector3 rotation_center = GetRotationCenter();
+        Quaternion rot = Quaternion(Radian(m_rotation_request), Vector3::UNIT_Y);
+
+        for (int i = 0; i < ar_num_nodes; i++)
+        {
+            ar_nodes[i].AbsPosition -= rotation_center;
+            ar_nodes[i].AbsPosition = rot * ar_nodes[i].AbsPosition;
+            ar_nodes[i].AbsPosition += rotation_center;
+            ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
+        }
+
+        m_rotation_request = 0.0f;
+        updateBoundingBox();
+        calculateAveragePosition();
+    }
+
+    if (m_translation_request != Vector3::ZERO)
+    {
+        for (int i = 0; i < ar_num_nodes; i++)
+        {
+            ar_nodes[i].AbsPosition += m_translation_request;
+            ar_nodes[i].RelPosition = ar_nodes[i].AbsPosition - ar_origin;
+        }
+
+        m_translation_request = 0.0f;
+        updateBoundingBox();
+        calculateAveragePosition();
+    }
+
     if (m_reset_request)
+    {
         SyncReset();
+    }
 }
 
 void Actor::sendStreamSetup()

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -84,8 +84,6 @@ public:
     void              UpdateNetworkInfo();
     bool              AddTyrePressure(float v);
     float             GetTyrePressure();
-    void              ResetAngle(float rot);
-    void              ResetPosition(float px, float pz, bool setInitPosition, float miny);
     float             getRotation();
     Ogre::Vector3     getDirection();
     Ogre::Vector3     getPosition();
@@ -94,12 +92,13 @@ public:
     /// @param setInitPosition Set initial positions of nodes to current position?
     void              ResetPosition(Ogre::Vector3 translation, bool setInitPosition);
     void              RequestActorReset(bool keepPosition = false);    //!< reset the actor from any context
-    void              displace(Ogre::Vector3 translation, float rotation);
+    void              RequestRotation(float rotation);
+    void              RequestTranslation(Ogre::Vector3 translation);
     Ogre::Vector3     GetRotationCenter();                 //!< Return the rotation center of the actor
     bool              ReplayStep();
     void              ForceFeedbackStep(int steps);
-    void              UpdateAngelScriptEvents(float dt);
-    void              HandleResetRequests(float dt);
+    void              HandleInputEvents(float dt);
+    void              HandleAngelScriptEvents(float dt);
     void              UpdateSoundSources();
     void              HandleMouseMove(int node, Ogre::Vector3 pos, float force); //!< Event handler
     void              ToggleLights();                      //!< Event handler
@@ -404,6 +403,8 @@ private:
     void              resetSlideNodePositions();           //!< Recalculate SlideNode positions
     void              resetSlideNodes();                   //!< Reset all the SlideNodes
     void              updateSlideNodePositions();          //!< incrementally update the position of all SlideNodes
+    void              ResetAngle(float rot);
+    void              ResetPosition(float px, float pz, bool setInitPosition, float miny);
     /// @param actor which actor to retrieve the closest Rail from
     /// @param node which SlideNode is being checked against
     /// @return a pair containing the rail, and the distant to the SlideNode
@@ -456,6 +457,8 @@ private:
     Ogre::SceneNode*  m_net_label_node;
     Ogre::String      m_net_username;
     float             m_custom_light_toggle_countdown; //!< Input system helper status
+    float             m_rotation_request;         //!< Accumulator
+    Ogre::Vector3     m_translation_request;      //!< Accumulator
     Ogre::Vector3     m_camera_gforces_accu;      //!< Accumulator for 'camera' G-forces
     int               m_camera_gforces_count;     //!< Counter for 'camera' G-forces
     float             m_ref_tyre_pressure;        //!< Physics state

--- a/source/main/physics/BeamFactory.cpp
+++ b/source/main/physics/BeamFactory.cpp
@@ -1185,8 +1185,8 @@ void ActorManager::UpdateActors(Actor* player_actor, float dt)
 
     for (auto actor : m_actors)
     {
-        actor->HandleResetRequests(dt);
-        actor->UpdateAngelScriptEvents(dt);
+        actor->HandleInputEvents(dt);
+        actor->HandleAngelScriptEvents(dt);
 
 #ifdef USE_ANGELSCRIPT
         if (actor->ar_vehicle_ai && (actor->ar_vehicle_ai->IsActive()))


### PR DESCRIPTION
Instead of modifying node data inside of `UpdateInputEvents()` queue the requested changes and apply them later - during the physics update. Fixes all related issues:
- No more stuttering
- Skeleton view no longer out of sync

... hopefully a first step into the right direction.

The `HandleInputEvents()` method in its current state is obviously just a placeholder.