### PR TITLE
Removed obsolete 'IsNodeIdValid()' method

### DIFF
--- a/source/main/gfx/camera/CameraManager.cpp
+++ b/source/main/gfx/camera/CameraManager.cpp
@@ -215,12 +215,20 @@ void CameraManager::UpdateCurrentBehavior()
     case CAMERA_BEHAVIOR_VEHICLE_CINECAM: {
         CameraManager::CameraBehaviorOrbitUpdate();
 
-        Vector3 dir  = m_cct_player_actor->GetCameraDir (m_cct_player_actor->ar_current_cinecam);
-        Vector3 roll = m_cct_player_actor->GetCameraRoll(m_cct_player_actor->ar_current_cinecam);
+        int pos_node  = m_cct_player_actor->ar_camera_node_pos [m_cct_player_actor->ar_current_cinecam];
+        int dir_node  = m_cct_player_actor->ar_camera_node_dir [m_cct_player_actor->ar_current_cinecam];
+        int roll_node = m_cct_player_actor->ar_camera_node_roll[m_cct_player_actor->ar_current_cinecam];
+
+        Vector3 dir  = (m_cct_player_actor->ar_nodes[pos_node].AbsPosition
+                - m_cct_player_actor->ar_nodes[dir_node].AbsPosition).normalisedCopy();
+        Vector3 roll = (m_cct_player_actor->ar_nodes[pos_node].AbsPosition
+                - m_cct_player_actor->ar_nodes[roll_node].AbsPosition).normalisedCopy();
+
         if ( m_cct_player_actor->ar_camera_node_roll_inv[m_cct_player_actor->ar_current_cinecam] )
         {
             roll = -roll;
         }
+
         Vector3 up = dir.crossProduct(roll);
         roll = up.crossProduct(dir);
 

--- a/source/main/physics/Beam.cpp
+++ b/source/main/physics/Beam.cpp
@@ -381,28 +381,6 @@ Vector3 Actor::getPosition()
     return m_avg_node_position; //the position is already in absolute position
 }
 
-Vector3 Actor::GetCameraDir(int camera_index)
-{
-    int pos_id = ar_camera_node_pos[camera_index];
-    int dir_node = ar_camera_node_dir[camera_index];
-    if (pos_id != dir_node && this->IsNodeIdValid(pos_id) && this->IsNodeIdValid(dir_node))
-    {
-        return (ar_nodes[pos_id].RelPosition - ar_nodes[dir_node].RelPosition).normalisedCopy();
-    }
-    return Vector3::ZERO;
-}
-
-Vector3 Actor::GetCameraRoll(int camera_index)
-{
-    int pos_id = ar_camera_node_pos[camera_index];
-    int roll_id = ar_camera_node_roll[camera_index];
-    if (pos_id != roll_id && this->IsNodeIdValid(pos_id) && this->IsNodeIdValid(roll_id))
-    {
-        return (ar_nodes[pos_id].RelPosition - ar_nodes[roll_id].RelPosition).normalisedCopy();
-    }
-    return Vector3::ZERO;
-}
-
 void Actor::PushNetwork(char* data, int size)
 {
     if (!oob3)
@@ -4036,7 +4014,7 @@ void Actor::updateDashBoards(float dt)
 
 Vector3 Actor::getGForces()
 {
-    if (this->IsNodeIdValid(ar_camera_node_pos[0]))
+    if (ar_camera_node_pos[0] >= 0)
     {
         static Vector3 result = Vector3::ZERO;
         if (m_camera_gforces_count == 0) // multiple calls in one single frame, avoid division by 0

--- a/source/main/physics/Beam.h
+++ b/source/main/physics/Beam.h
@@ -180,8 +180,6 @@ public:
     std::list<Actor*> GetAllLinkedActors()              { return m_linked_actors; }; //!< Returns a list of all connected (hooked) actors
     Ogre::Vector3     GetCameraDir()                    { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_dir].RelPosition).normalisedCopy(); }
     Ogre::Vector3     GetCameraRoll()                   { return (ar_nodes[ar_main_camera_node_pos].RelPosition - ar_nodes[ar_main_camera_node_roll].RelPosition).normalisedCopy(); }
-    Ogre::Vector3     GetCameraDir(int camera_index);
-    Ogre::Vector3     GetCameraRoll(int camera_index);
     Ogre::Vector3     GetFFbBodyForces() const          { return m_force_sensors.out_body_forces; }
     PointColDetector* IntraPointCD()                    { return m_intra_point_col_detector; }
     PointColDetector* InterPointCD()                    { return m_inter_point_col_detector; }
@@ -193,7 +191,6 @@ public:
     float             GetFFbHydroForces() const         { return m_force_sensors.out_hydros_forces; }
     bool              isPreloadedWithTerrain() const    { return m_preloaded_with_terrain; };
     VehicleAI*        getVehicleAI()                    { return ar_vehicle_ai; }
-    bool              IsNodeIdValid(int id) const       { return (id >= 0) && (id < ar_num_nodes); }
     float             getWheelSpeed() const             { return ar_wheel_speed; }
     int               GetNumNodes() const               { return ar_num_nodes; }
     Ogre::Vector3     getVelocity() const               { return m_avg_node_velocity; }; //!< average actor velocity, calculated using the actor positions of the last two frames


### PR DESCRIPTION
For reference, this is how is looks like on master: https://github.com/RigsOfRods/rigs-of-rods/blob/master/source/main/gfx/camera/CameraManager.cpp#L193-L206

-> this basically reverts a small part of the last cleanup pull request in order to get rid of the entire `IsNodeIdValid()` method including the ugly helper methods that made use of it.